### PR TITLE
Fix whitespace in control file

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -24,7 +24,6 @@ Build-Depends: cmake,
                libignition-rendering3-dev (>= 3.5.0),
                libignition-transport8-log-dev,
                libsdformat9-dev (>= 9.6.0)
-
 Vcs-Browser: https://github.com/ignition-release/ign-gazebo3-release
 Vcs-Hg: https://github.com/ignition-release/ign-gazebo3-release
 Homepage: http://ignitionrobotics.org/


### PR DESCRIPTION
Follow up to https://github.com/ignition-release/ign-gazebo3-release/pull/12/files#r737020907

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-gazebo3-debbuilder&build=112)](https://build.osrfoundation.org/job/ign-gazebo3-debbuilder/112/) https://build.osrfoundation.org/job/ign-gazebo3-debbuilder/112/

~~~
dpkg-buildpackage: error: syntax error in debian/control at line 31: block lacks the 'Package' field
~~~