### PR TITLE
Prepare for 3.15.0

### DIFF
--- a/bionic/debian/changelog
+++ b/bionic/debian/changelog
@@ -1,3 +1,9 @@
+ignition-gazebo3 (3.15.0-1~bionic) bionic; urgency=medium
+
+  * ignition-gazebo3 3.15.0-1 release
+
+ -- Addisu Z. Taddese <addisu@openrobotics.org>  Mon, 08 May 2023 14:48:03 -0500
+
 ignition-gazebo3 (3.14.0-1~bionic) bionic; urgency=medium
 
   * ignition-gazebo3 3.14.0-1 release

--- a/focal/debian/changelog
+++ b/focal/debian/changelog
@@ -1,3 +1,9 @@
+ignition-gazebo3 (3.15.0-1~focal) focal; urgency=medium
+
+  * ignition-gazebo3 3.15.0-1 release
+
+ -- Addisu Z. Taddese <addisu@openrobotics.org>  Mon, 08 May 2023 14:48:03 -0500
+
 ignition-gazebo3 (3.14.0-1~focal) focal; urgency=medium
 
   * ignition-gazebo3 3.14.0-1 release

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -37,10 +37,10 @@ Depends: ${shlibs:Depends},
          qml-module-qtqml-models2
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - Shared library
-  Gazebo Sim is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  Main shared library
+ Gazebo Sim is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ Main shared library
 
 Package: libignition-gazebo3-plugins
 Architecture: any
@@ -49,10 +49,10 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - Plugins
-  Gazebo Sim is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  Plugins collection
+ Gazebo Sim is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ Plugins collection
 
 Package: libignition-gazebo3-dev
 Architecture: any
@@ -79,10 +79,10 @@ Depends: libtinyxml2-dev,
          ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - Development files
-  Gazebo Sim is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  Development files
+ Gazebo Sim is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ Development files
 
 Package: libignition-gazebo3-dbg
 Architecture: any
@@ -93,10 +93,10 @@ Depends:
      ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - Debug symbols
-  Gazebo Sim is a component in the Gazebo framework, a set of libraries
-  designed to rapidly develop robot applications.
-  .
-  Debug symbols
+ Gazebo Sim is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ Debug symbols
 
 Package: libgz-sim3
 Depends: libignition-gazebo3, ${misc:Depends}


### PR DESCRIPTION
Also, while checking if the metadata needs updating, I fixed some lintian errors. @scpeters as far as I can tell, the `libignition-gazebo-dev.install` file uses glob patterns, so it doesn't need to be updated after the ign->gz migration. Usually, `debuild` warns if there are files in the temporary install directory not included in the debs, but I didn't get any warnings about that.